### PR TITLE
Add gitconfig to make main the default branch.

### DIFF
--- a/files/gitconfig
+++ b/files/gitconfig
@@ -1,0 +1,3 @@
+[init]
+  defaultBranch = main
+

--- a/packages.yml
+++ b/packages.yml
@@ -112,6 +112,12 @@
           state: latest
           force_apt_get: yes
 
+      - name: Add /etc/gitconfig
+        copy:
+          src: files/gitconfig
+          dest: /etc/gitconfig
+        tags: packages
+
       - name: Install desktop
         tags: packages
         apt:


### PR DESCRIPTION
Otherwise, git will show a warning on first use. If we want the students to see this warning, then this should not be merged, obviously.

(Not sure about the ansible tag to use.)