### PR TITLE
Adding ssh fingerprint for github

### DIFF
--- a/user-setup.yml
+++ b/user-setup.yml
@@ -171,4 +171,9 @@
         tags: remote
         command: gsettings set org.gnome.desktop.background picture-uri '"file:///home/student/Desktop/wallpaper.jpg"'
 
-
+      - name: Add github to /home/student/.ssh/known_hosts
+        ansible.builtin.known_hosts:
+          path: /home/student/.ssh/known_hosts
+          name: github.com
+          key: github.com ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOMqqnkVzrm0SdG6UOoqKLsabgH5C9okWi0dh2l9GKJl
+          state: present


### PR DESCRIPTION
This should be tested with the USB sticks.

I don’t remember the details, but I think when people got the message to unlock the ssh key on the USB stick, it was very hard to miss the do-you-want-to-accept the ssh fingerprint for github message. Therefore it would be useful to have it added as a default.

Closes #9 
