### PR TITLE
Only run cleanup tasks when explicitly specified

### DIFF
--- a/roles/user-setup/tasks/main.yml
+++ b/roles/user-setup/tasks/main.yml
@@ -80,12 +80,14 @@
     path: "/home/student/.bash_history"
     state: absent
   tags: cleanup
+  when: "'cleanup' in ansible_run_tags"
 
 - name: Remove .ipynb_checkpoints/
   file:
     path: "/home/student/.ipynb_checkpoints/"
     state: absent
   tags: cleanup
+  when: "'cleanup' in ansible_run_tags"
 
 - name: Set input keyboards to us/gr
   dconf:


### PR DESCRIPTION
To avoid running the cleanup tasks during a normal run (with no `--tags` specified), we should add something like this to all `cleanup` tasks or generally to all tasks that should never be run accidentally.

    - name: ...
      tags:
        - cleanup
      when: "'cleanup' in ansible_run_tags"

https://serverfault.com/a/1003479 

Importantly, this solution should also work when the cleanup task has more tags, either directly or indirectly (given to it in the main playbook).

We can then also remove the list of `pull_tags` from the ansible-pull services for simplicity. (Though tags can still be useful to speed up specific fixes.)