### PR TITLE
New tags and tagged stages. Added README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,51 @@
+# ASPP laptop installation helpers
+
+## How to install
+
+There are two main playbooks in this repository:
+
+`setup-ansible.yml`, which creates the ansible-pull timer and services on a computer but does not activate them.
+
+`all.yml`, which enables and starts the timers and then does a full installation of the ASPP laptop.
+
+Depending on whether the installation should be done on a disk image or on a pre-setup laptop, there are two suggested modes of installation:
+
+1) For a minimal installation to a disk image:
+
+       ansible-pull -i localhost, -U https://github.com/ASPP/installation setup-ansible.yml
+
+    After the disk image has been copied to a laptop, it is suggested to mount the root folder and manually enable the ansible timers. After a reboot, the system should then auto-install.
+
+2) For a full installation:
+
+       ansible-pull -i localhost, -U https://github.com/ASPP/installation all.yml
+
+## Tags
+
+Using
+
+    ansible-playbook --list-tags all.yml
+
+or
+
+    ansible-playbook --list-tasks all.yml
+
+it is possible to show the list of currently used tags.
+
+Each task should have one of the following tags:
+
+    - packages
+    - graphical-packages
+    - config
+    - user-creation
+    - user-packages
+    - user-config
+
+If in doubt, the playbook should be run untagged, but when only minor additions are made to the playbook, specifying a tag may speed things up.
+
+
+Furthermore, the individual stages have also been tagged:
+
+    - stage-basic
+    - stage-user
+    - stage-bonus

--- a/all.yml
+++ b/all.yml
@@ -1,6 +1,9 @@
 ---
+# Full ASPP laptop setup with enabled+started ansible-pull timers
+
 - name: Basic ASPP laptop setup
   hosts: all
+  tags: stage-basic
 
   roles:
     - role: ansible-pull
@@ -11,6 +14,7 @@
 
 - name: ASPP user setup
   hosts: all
+  tags: stage-user
 
   remote_user: root
   become_user: student
@@ -21,6 +25,7 @@
 
 - name: ASPP bonus setup
   hosts: all
+  tags: stage-bonus
 
   roles:
     - role: music-setup

--- a/roles/ansible-pull/tasks/main.yml
+++ b/roles/ansible-pull/tasks/main.yml
@@ -7,13 +7,13 @@
 - name: Install ansible
   dnf:
     name: ansible, git, dbus-tools
-  tags: packages,remote
+  tags: packages
 
 - name: Create unit directory
   file:
     path: /usr/local/lib/systemd/system/
     state: directory
-  tags: remote
+  tags: config
 
 - name: Install ansible-pull-init.timer
   copy:
@@ -24,7 +24,7 @@
 
       [Install]
       WantedBy=multi-user.target
-  tags: remote
+  tags: config
 
 - name: Install ansible-pull-repeat.timer
   copy:
@@ -35,7 +35,7 @@
 
       [Install]
       WantedBy=multi-user.target
-  tags: remote
+  tags: config
 
 - name: Install ansible-pull-init.service
   copy:
@@ -52,7 +52,7 @@
       ExecStart=ansible-pull -i localhost, -U {{ ansible_repo_url }} {% if pull_tags is defined and pull_tags %} -t {{ pull_tags }} {% endif %} all.yml
       Restart=on-failure
       RestartSec=5 min
-  tags: remote
+  tags: config
 
 - name: Install ansible-pull-repeat.service
   copy:
@@ -68,13 +68,13 @@
       ExecStart=ansible-pull -i localhost, -U {{ ansible_repo_url }} --only-if-changed {% if pull_tags is defined and pull_tags %} -t {{ pull_tags }} {% endif %} all.yml
       Restart=on-failure
       RestartSec=1 min
-  tags: remote
+  tags: config
 
 - name: Create override folder for ansible-pull.service
   file:
     path: /usr/local/lib/systemd/system/ansible-pull-.service.d
     state: directory
-  tags: remote
+  tags: config
 
 - name: Add ara config to ansible-pull
   copy:
@@ -85,28 +85,28 @@
       Environment=ARA_API_CLIENT=http
       # This should be set dynamically: python3 -m ara.setup.callback_plugins
       Environment=ANSIBLE_CALLBACK_PLUGINS=/usr/lib/python3.12/site-packages/ara/plugins/callback
-  tags: remote
+  tags: config
 
 - name: Enable ansible-pull-init.timer
   ansible.builtin.systemd_service:
     name: ansible-pull-init.timer
     enabled: "{{ ansible_pull_timer_enabled }}"
     daemon_reload: true
-  tags: remote
+  tags: config
 
 - name: Enable ansible-pull-repeat.timer
   ansible.builtin.systemd_service:
     name: ansible-pull-repeat.timer
     enabled: "{{ ansible_pull_timer_enabled }}"
     daemon_reload: true
-  tags: remote
+  tags: config
 
 
 - name: Enable ansible-pull-init.timer
   ansible.builtin.systemd_service:
     name: ansible-pull-init.timer
     state: "started"
-  tags: remote
+  tags: config
   when: ansible_pull_timer_started
 
 - name: Enable ansible-pull-repeat.timer
@@ -114,5 +114,5 @@
     name: ansible-pull-repeat.timer
     state: "started"
     daemon_reload: true
-  tags: remote
+  tags: config
   when: ansible_pull_timer_started

--- a/roles/chatgpt-guard/tasks/main.yml
+++ b/roles/chatgpt-guard/tasks/main.yml
@@ -1,21 +1,24 @@
 ---
 - name: Install pre-compiled mkcert
-  tags: remote,packages
+  tags: packages
   ansible.builtin.copy:
     src: mkcert
     mode: "0755"
     dest: /usr/local/bin/
 
 - name: Clone ChatGPT-Guard repo
+  tags: packages
   ansible.builtin.git:
     repo: "{{ repo_url }}"
     dest: /srv/chatgpt-guard
 
 - name: Enable ChatGPT-Guard units
+  tags: config
   ansible.builtin.command:
     cmd: /srv/chatgpt-guard/do_setup.sh
 
 - name: Force-enable chatgpt-ssl
+  tags: config
   ansible.builtin.systemd_service:
     name: chatgpt-guard-ssl.service
     state: started

--- a/roles/common/tasks/packages.yml
+++ b/roles/common/tasks/packages.yml
@@ -135,7 +135,7 @@
 - name: Install distro packages (Fedora)
   ansible.builtin.dnf:
     name: "{{ packages }}"
-  tags: packages, graphical
+  tags: packages, graphical-packages
   vars:
     packages:
       # Desktop
@@ -168,7 +168,7 @@
 - import_tasks: packages_vscode.yml
 
 - name: Install pre-compiled py-spy
-  tags: remote,packages
+  tags: packages
   ansible.builtin.copy:
     src: files/py-spy
     mode: "0755"

--- a/roles/common/tasks/packages_vscode.yml
+++ b/roles/common/tasks/packages_vscode.yml
@@ -1,12 +1,12 @@
 ---
 - name: Add key for vscode repository
-  tags: packages,visualstudio,graphical
+  tags: packages, visualstudio, graphical-packages
   ansible.builtin.rpm_key:
     state: present
     key: https://packages.microsoft.com/keys/microsoft.asc
 
 - name: Add vscode repository
-  tags: packages,visualstudio,graphical
+  tags: packages, visualstudio, graphical-packages
   ansible.builtin.yum_repository:
     name: vscode
     description: Visual Studio Code
@@ -14,6 +14,6 @@
     gpgkey: https://packages.microsoft.com/keys/microsoft.asc
 
 - name: Install visualstudio code
-  tags: packages,visualstudio,graphical
+  tags: packages, visualstudio, graphical-packages
   ansible.builtin.dnf:
     name: code

--- a/roles/common/tasks/services.yml
+++ b/roles/common/tasks/services.yml
@@ -1,18 +1,20 @@
 ---
 - name: Disable packagekit.service manually
+  tags: config
   ansible.builtin.file:
     src: /dev/null
     dest: /etc/systemd/system/packagekit.service
     state: link
 
 - name: Disable packagekit-offline-update.service manually
+  tags: config
   ansible.builtin.file:
     src: /dev/null
     dest: /etc/systemd/system/packagekit-offline-update.service
     state: link
 
 - name: Disable packagekit.service
-  tags: remote
+  tags: config
   ansible.builtin.systemd_service:
     name: packagekit.service
     state: stopped
@@ -21,7 +23,7 @@
   ignore_errors: true
 
 - name: Disable packagekit-offline-update.service
-  tags: remote
+  tags: config
   ansible.builtin.systemd_service:
     name: packagekit-offline-update.service
     state: stopped
@@ -30,7 +32,7 @@
   ignore_errors: true
 
 - name: Disable pmlogger.service
-  tags: remote
+  tags: config
   ansible.builtin.systemd_service:
     name: pmlogger.service
     state: stopped
@@ -39,7 +41,7 @@
   ignore_errors: true
 
 - name: Disable pmlogger_farm.service
-  tags: remote
+  tags: config
   ansible.builtin.systemd_service:
     name: pmlogger_farm.service
     state: stopped
@@ -48,7 +50,7 @@
   ignore_errors: true
 
 - name: Enable growfs-root.service manually
-  tags: remote
+  tags: config
   ansible.builtin.file:
     src: /usr/lib/systemd/system/growfs-root.service
     dest: /etc/systemd/system/sysinit.target.wants/growfs-root.service

--- a/roles/common/tasks/users.yml
+++ b/roles/common/tasks/users.yml
@@ -1,21 +1,21 @@
 ---
 - name: Create student user
+  tags: user-creation
   user:
     name: student
     comment: ASPP Student
     groups: adm, wheel
     password: "{{ student_password }}"
     shell: "/bin/bash"
-  tags: user-creation
 
 - name: Set authorized key
+  tags: user-creation
   authorized_key:
     user: student
     state: present
     key: "ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBAEgEXiWzskC+g+5Va0qtiLi3yiT1UL+ENruRwEgX5FnlknJuKE7NM+6LYccG4MKlgjymbQKN02L7g4E/FRJPJk= student@aspp"
     exclusive: false
   ignore_errors: true
-  tags: user-creation
 
 - name: Allow password authentication (Fedora)
   tags: user-creation
@@ -24,6 +24,7 @@
       PasswordAuthentication yes
 
     dest: /etc/ssh/sshd_config.d/80-password-auth.conf
+  notify: Reload sshd config
 
 - name: Allow X forwarding (Fedora)
   tags: user-creation
@@ -32,58 +33,53 @@
       ForwardX11 yes
 
     dest: /etc/ssh/ssh_config.d/80-x-forwarding.conf
-
-- name: Reload sshd config
-  tags: user-creation
-  ansible.builtin.systemd_service:
-    name: sshd.service
-    state: reloaded
+  notify: Reload sshd config
 
 - name: Set up autologin
+  tags: user-creation
   copy:
     src: gdm-custom.conf
     dest: /etc/gdm/
-  tags: user-creation
 
 - name: Create firefox preferences directory
+  tags: config
   file:
     path: /usr/lib64/firefox/browser/defaults/preferences/
     state: directory
-  tags: remote
 
 - name: Setup firefox homepage
+  tags: config
   copy:
     content: |
       pref("browser.startup.homepage", "data:text/plain,browser.startup.homepage=https://aspp.school/wiki/schedule");
 
     dest: /usr/lib64/firefox/browser/defaults/preferences/firefox-aspp.js
 
-  tags: remote
-
 - name: Set timezone to Europe/Athens
+  tags: config
   timezone:
     name: Europe/Athens
-  tags: remote
 
 - name: Add English langpack
+  tags: packages
   ansible.builtin.dnf:
     name: glibc-langpack-en
-  tags: packages
 
 - name: Set language to English
+  tags: config
   copy:
     content: |
       LANG=en_US.UTF-8
     dest: /etc/locale.conf
-  tags: remote
 
 - name: Create local unit directory
+  tags: config
   file:
     path: /usr/local/lib/systemd/user/
     state: directory
-  tags: remote
 
 - name: Install keyadder service
+  tags: config
   copy:
     dest: /usr/local/lib/systemd/user/keyadder@.service
     content: |
@@ -97,25 +93,23 @@
       Type=oneshot
       RemainAfterExit=true
 
-  tags: remote
-
 - name: Create local unit directory
+  tags: config
   file:
     path: /usr/local/lib/systemd/user/run-media-.mount.d
     state: directory
-  tags: remote
 
 - name: Install keyadder service
+  tags: config
   copy:
     dest: /usr/local/lib/systemd/user/run-media-.mount.d/keyadder.conf
     content: |
       [Unit]
       Wants=keyadder@%N.service
 
-  tags: remote
 
 - name: Install Wifi connection profile
+  tags: config
   copy:
     src: files/FORTH_Guests.nmconnection
     dest: /etc/NetworkManager/system-connections/
-  tags: remote

--- a/roles/music-setup/tasks/main.yml
+++ b/roles/music-setup/tasks/main.yml
@@ -1,36 +1,43 @@
 ---
 - name: Copy music folder
+  tags: config
   ansible.builtin.copy:
     src: "music/"
     dest: "/home/student/.music/"
 
 - name: Set up timers
+  tags: config
   ansible.builtin.copy:
     src: "aspp-music-finalcountdown.service"
     dest: "/etc/systemd/system/"
 
 - name: Set up timers
+  tags: config
   ansible.builtin.copy:
     src: "aspp-music-finalcountdown.timer"
     dest: "/etc/systemd/system/"
 
 - name: Set up timers
+  tags: config
   ansible.builtin.copy:
     src: "aspp-music-pushit.service"
     dest: "/etc/systemd/system/"
 
 - name: Set up timers
+  tags: config
   ansible.builtin.copy:
     src: "aspp-music-pushit.timer"
     dest: "/etc/systemd/system/"
 
 - name: Enable music
+  tags: config
   ansible.builtin.systemd_service:
     name: aspp-music-pushit.timer
     state: started
     daemon_reload: true
 
 - name: Enable music
+  tags: config
   ansible.builtin.systemd_service:
     name: aspp-music-finalcountdown.timer
     state: started

--- a/roles/user-setup/tasks/main.yml
+++ b/roles/user-setup/tasks/main.yml
@@ -3,7 +3,7 @@
   ansible.builtin.command: xdg-user-dirs-update
   # Creates ~/Desktop, ~/Downloads ... and .config folders
   # Unfortunately not .cache and .local
-  tags: remote
+  tags: user-config
 
 - name: Install pip packages (Fedora)
   tags: user-packages
@@ -29,12 +29,12 @@
     repo: https://github.com/Debilski/vim-basic.git
     dest: /home/student/.config/vim
     update: false
-  tags: remote
+  tags: user-config
   register: vim_config
 
 - name: Install vim plugins
   ansible.builtin.command: 'vim +PlugInstall +qall'
-  tags: remote
+  tags: user-config
   when: vim_config.changed
 
 - name: Kickstart neovim
@@ -42,16 +42,16 @@
     repo: https://github.com/nvim-lua/kickstart.nvim.git
     dest: /home/student/.config/nvim
     update: false
-  tags: remote
+  tags: user-config
   register: nvim_config
 
 - name: Install nvim plugins
   ansible.builtin.command: 'nvim --headless "+Lazy! sync" +qa'
-  tags: remote
+  tags: user-config
   when: nvim_config.changed
 
 - name: Set up git
-  tags: remote
+  tags: user-config
   copy:
     content: |
       [core]
@@ -65,12 +65,12 @@
     dest: /home/student/.gitconfig
 
 - name: Disable screensaver
-  tags: remote
+  tags: user-config
   command: gsettings set org.gnome.desktop.session idle-delay 0
   ignore_errors: true
 
 - name: Disable screen lock
-  tags: remote
+  tags: user-config
   command: gsettings set org.gnome.desktop.lockdown disable-lock-screen true
   ignore_errors: true
 
@@ -78,42 +78,44 @@
   file:
     dest: "/home/student/.local/bin/"
     state: directory
-  tags: remote
+  tags: user-config
 
 - name: Install .bashrc.d/
   copy:
     src: "bashrc.d/"
     dest: "/home/student/.bashrc.d/"
-  tags: remote
+  tags: user-config
 
 - name: Create directory .config/micro
   file:
     path: /home/student/.config/micro/
     state: directory
-  tags: remote
+  tags: user-config
+
 - name: Install .config/micro/settings.json
   copy:
     src: "micro-settings.json"
     dest: "/home/student/.config/micro/settings.json"
-  tags: remote
+  tags: user-config
+
 - name: Install .config/micro/bindings.json
   copy:
     src: "micro-bindings.json"
     dest: "/home/student/.config/micro/bindings.json"
-  tags: remote
+  tags: user-config
 
 - name: Remove .bash_history
   file:
     path: "/home/student/.bash_history"
     state: absent
-  tags: cleanup
+  tags: cleanup, user-config
   when: "'cleanup' in ansible_run_tags"
 
 - name: Remove .ipynb_checkpoints/
   file:
     path: "/home/student/.ipynb_checkpoints/"
     state: absent
-  tags: cleanup
+  tags: cleanup, user-config
   when: "'cleanup' in ansible_run_tags"
 
 - name: Set input keyboards to us/gr
@@ -121,28 +123,28 @@
     key: /org/gnome/desktop/input-sources/sources
     value: "[('xkb', 'us'), ('xkb', 'gr')]"
     state: present
-  tags: remote
+  tags: user-config
 
 - name: Disable lock screen
   dconf:
     key: /org/gnome/desktop/lockdown/disable-lock-screen
     value: "true"
     state: present
-  tags: remote
+  tags: user-config
 
 - name: Disable screen dimming
   dconf:
     key: /org/gnome/settings-daemon/plugins/power/idle-dim
     value: "false"
     state: present
-  tags: remote
+  tags: user-config
 
 - name: Show battery percentage
   dconf:
     key: /org/gnome/desktop/interface/show-battery-percentage
     value: "true"
     state: present
-  tags: remote
+  tags: user-config
 
   # TODO: This should be set once and not override what the user has chosen
 - name: Make Gnome terminal follow the System theme
@@ -150,21 +152,21 @@
     key: /org/gnome/terminal/legacy/theme-variant
     value: "'system'"
     state: present
-  tags: remote
+  tags: user-config
 
 - name: Disable annoying terminal sounds
   dconf:
     key: /org/gnome/desktop/sound/event-sounds
     value: "false"
     state: present
-  tags: remote
+  tags: user-config
 
 - name: Setup favourites
   dconf:
     key: /org/gnome/shell/favorite-apps
     value: "['firefox.desktop', 'org.gnome.Terminal.desktop', 'org.gnome.Nautilus.desktop', 'code.desktop', 'libreoffice-writer.desktop']"
     state: present
-  tags: remote
+  tags: user-config
 
 # Gnome text editor defaults
 - name: Gnome text editor enable line numbers
@@ -172,41 +174,41 @@
     key: /org/gnome/TextEditor
     value: "true"
     state: present
-  tags: remote
+  tags: user-config
 
 - name: Gnome text editor indent with space
   dconf:
     key: /org/gnome/TextEditor
     value: "'space'"
     state: present
-  tags: remote
+  tags: user-config
 
 - name: Gnome text editor tab width 4
   dconf:
     key: /org/gnome/TextEditor
     value: "4"
     state: present
-  tags: remote
+  tags: user-config
 
 - name: Create ~/Desktop
   ansible.builtin.file:
     path: "/home/student/Desktop"
     state: directory
     mode: "0755"
-  tags: remote
+  tags: user-config
 
 - name: Copy background
   copy:
     src: "files/aspp_2024_background.png"
     dest: "/home/student/Desktop/wallpaper.png"
-  tags: remote
+  tags: user-config
 
 - name: Activate background
-  tags: remote
+  tags: user-config
   command: gsettings set org.gnome.desktop.background picture-uri '"file:///home/student/Desktop/wallpaper.png"'
 
 - name: Add github to /home/student/.ssh/known_hosts
-  tags: remote
+  tags: user-config
   ansible.builtin.known_hosts:
     path: /home/student/.ssh/known_hosts
     name: github.com
@@ -220,7 +222,7 @@
     mode: "0755"
     owner: student
     group: student
-  tags: remote
+  tags: user-config
   loop:
     - /home/student/.local
     - /home/student/.local/share
@@ -240,4 +242,4 @@
     mode: "0755"
     owner: student
     group: student
-  tags: remote
+  tags: user-config

--- a/setup-ansible.yml
+++ b/setup-ansible.yml
@@ -4,4 +4,3 @@
 
   roles:
     - ansible-pull
-


### PR DESCRIPTION
I went through all tasks and removed the `remote` tag, which I think was redundant. There are tags now that distinguish between installing packages and configuration (both for the system and for the student user).

Additionally, I have added tagged stages to `all.yml` that might be useful in some cases. (Maybe to test out additional bonus material easily.)

The part

> After the disk image has been copied to a laptop, it is suggested to mount the root folder and manually enable the ansible timers.

is a bit handwavy. We should add a complete description on how to do install an image with `dd` or  `systemd-repart` and then how to mount this image and `ln -s` for the timer activation.